### PR TITLE
Fixed build error when used with VTK7

### DIFF
--- a/ModelToModelDistance/vtkImplicitPolyDataDistance_m.cxx
+++ b/ModelToModelDistance/vtkImplicitPolyDataDistance_m.cxx
@@ -76,7 +76,7 @@ void vtkImplicitPolyDataDistance_m::SetInput(vtkPolyData* input)
 }
 
 //-----------------------------------------------------------------------------
-unsigned long vtkImplicitPolyDataDistance_m::GetMTime()
+vtkMTimeType vtkImplicitPolyDataDistance_m::GetMTime()
 {
   unsigned long mTime=this->vtkImplicitFunction::GetMTime();
   unsigned long InputMTime;

--- a/ModelToModelDistance/vtkImplicitPolyDataDistance_m.h
+++ b/ModelToModelDistance/vtkImplicitPolyDataDistance_m.h
@@ -52,7 +52,7 @@ public:
 
   // Description:
   // Return the MTime also considering the Input dependency.
-  unsigned long GetMTime();
+  vtkMTimeType GetMTime();
 
   // Description:
   // Evaluate plane equation of nearest triangle to point x[3].


### PR DESCRIPTION
Timestamp type has changed in VTK7, which caused build error in vtkImplicitPolyDataDistance_m.